### PR TITLE
Potential fix for code scanning alert no. 56: Incomplete URL substring sanitization

### DIFF
--- a/abc.js
+++ b/abc.js
@@ -195,7 +195,8 @@ function inicializarFormularioDeAutenticacion() {
                const previousPage = document.referrer;
                 try {
                     const domain = new URL(previousPage).hostname;
-                    if (domain.includes("grouvex.github.io")) {window.history.back();} else {window.location.href = "https://grouvex.github.io";
+                    const allowedHosts = ["grouvex.github.io"];
+                    if (allowedHosts.includes(domain)) {window.history.back();} else {window.location.href = "https://grouvex.github.io";
                     }
                 } catch (e) {console.error("Error al procesar la URL anterior:", e);window.location.href = "https://grouvex.github.io"; }
                     })
@@ -223,7 +224,8 @@ function inicializarFormularioDeAutenticacion() {
                const previousPage = document.referrer;
                 try {
                     const domain = new URL(previousPage).hostname;
-                    if (domain.includes("grouvex.github.io")) {window.history.back();} else {window.location.href = "https://grouvex.github.io";
+                    const allowedHosts = ["grouvex.github.io"];
+                    if (allowedHosts.includes(domain)) {window.history.back();} else {window.location.href = "https://grouvex.github.io";
                     }
                 } catch (e) {console.error("Error al procesar la URL anterior:", e);window.location.href = "https://grouvex.github.io"; }
                     }).catch((error) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Grouvex/grouvex.github.io/security/code-scanning/56](https://github.com/Grouvex/grouvex.github.io/security/code-scanning/56)

To fix the problem, we need to ensure that the domain check is performed correctly by parsing the URL and comparing the hostname against a whitelist of allowed hosts. This will prevent arbitrary hosts from being accepted if they contain the allowed host as a substring.

- Parse the URL using the `URL` constructor to extract the hostname.
- Compare the extracted hostname against a whitelist of allowed hosts.
- Update the code to use this approach in both instances where the domain check is performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
